### PR TITLE
Search bar_검색기능 완성

### DIFF
--- a/src/app/weekselect/page.js
+++ b/src/app/weekselect/page.js
@@ -107,7 +107,9 @@ export default function WeekSelect() {
         </div>
       </header>
 
-      <h1 className="weekselect-title">요일 순 웹툰</h1>
+      <h1 className="weekselect-title">
+        {result.length > 0 ? "검색 결과" : "요일 순 웹툰"}
+        </h1>
 
       <div className="weekselect-buttons">
         {days.map(day => (

--- a/src/app/weekselect/page.js
+++ b/src/app/weekselect/page.js
@@ -47,11 +47,19 @@ export default function WeekSelect() {
   }
 };
 
+const resetSearch = () => {
+  setQuery("");
+  setResult([]);
+  setError("");
+  setLoading(false);
+  setSelectedDay("월"); 
+};
+
 
   return (
     <div className="weekselect-container">
       <header className="header">
-        <img src="/wn.svg" alt="웹툰노트 로고" className="logo" />
+        <img src="/wn.svg" alt="웹툰노트 로고" className="logo" onClick={resetSearch}/>
         <div className="search-bar">
           <input
             type="text"

--- a/src/app/weekselect/page.js
+++ b/src/app/weekselect/page.js
@@ -1,50 +1,71 @@
 "use client";
 
 import { useState } from "react";
-import "../imagelist/imagelist.css";   // 🔴 빨간 카드 스타일
-import "./weekselect.css";            // 🔴 요일 선택 UI 스타일
-import ImageList from "../imagelist/page"; // 🔴 방금 만든 컴포넌트
+import "../imagelist/imagelist.css"; 
+import "./weekselect.css";
+import ImageList from "../imagelist/page";
 
 const days = ["월", "화", "수", "목", "금", "토", "일"];
 
-// 모든 요일에 ImageList 보여주기
-const dayContents = {
-  월: <ImageList />,
-  화: <ImageList />,
-  수: <ImageList />,
-  목: <ImageList />,
-  금: <ImageList />,
-  토: <ImageList />,
-  일: <ImageList />,
-};
-
 export default function WeekSelect() {
   const [selectedDay, setSelectedDay] = useState("월");
+  const [query, setQuery] = useState("");
+  const [result, setResult] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+
+  const handleSearch = async () => {
+  if (!query.trim()) {
+    alert("검색어를 입력해주세요");
+    return;
+  }
+
+  setLoading(true);
+  setError("");
+
+  const params = new URLSearchParams({
+    title: query,
+    day: selectedDay,
+    page: 1,
+  });
+
+  try {
+    const res = await fetch(
+      `https://webtoon-note-862566155052.asia-northeast3.run.app/webtoons?${params.toString()}`
+    );
+
+    if (!res.ok) throw new Error("서버 오류 발생");
+
+    const data = await res.json();
+    setResult(data.webtoons || []);
+  } catch (err) {
+    console.error("API 요청 오류:", err);
+    setError("검색 중 오류가 발생했습니다.");
+    setResult([]);
+  } finally {
+    setLoading(false);
+  }
+};
+
 
   return (
     <div className="weekselect-container">
-
       <header className="header">
-        <img src="/wn.svg" alt="웹툰노트 로고" className="logo"/>   
-      
-      
-      <div className="search-bar">
-        <input
-        type="text"
-        className="search-input"
-        placeholder="리뷰할 웹툰을 검색해보세요"
-        />
-
-        <button className="search-btn">
-          <img src="searchicon.svg" alt="검색 아이콘" className="search-icon"/>
-        </button>
-      </div>
-      
-        
-
+        <img src="/wn.svg" alt="웹툰노트 로고" className="logo" />
+        <div className="search-bar">
+          <input
+            type="text"
+            className="search-input"
+            placeholder="리뷰할 웹툰을 검색해보세요"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+          />
+          <button className="search-btn" onClick={handleSearch}>
+            <img src="searchicon.svg" alt="검색 아이콘" className="search-icon" />
+          </button>
+        </div>
       </header>
 
-    
       <h1 className="weekselect-title">요일 순 웹툰</h1>
 
       <div className="weekselect-buttons">
@@ -60,9 +81,25 @@ export default function WeekSelect() {
       </div>
 
       <div className="weekselect-content">
-        {dayContents[selectedDay]}
+        <ImageList />
+      </div>
+
+      <div style={{ marginTop: "40px" }}>
+        <h2>검색 결과</h2>
+        {loading && <div>검색 중...</div>}
+        {error && <div style={{ color: "red" }}>{error}</div>}
+        {!loading && !error && result.length === 0 && <div>검색 결과가 없습니다.</div>}
+
+        {result.map((w) => (
+          <div key={w.id} style={{ marginBottom: "12px", display: "flex", gap: "10px" }}>
+            <img src={w.thumbnail} width={80} alt={w.title} />
+            <div>
+              <div style={{ fontWeight: "bold" }}>{w.title}</div>
+              <div>{w.authors}</div>
+            </div>
+          </div>
+        ))}
       </div>
     </div>
-  )
+  );
 }
-


### PR DESCRIPTION
<img width="468" height="622" alt="image" src="https://github.com/user-attachments/assets/d5ba3935-a223-4e8f-973c-2c8aabac91bb" />


**수정사항 1. 검색기능**
기존엔 태그/시놉시스에 검색어가 포함되어있으면 그 웹툰들이 다 떴음
-> 제목에 검색어가 포함되어있으면 뜨도록 변경
+원랜 검색어 입력 후 돋보기 버튼을 커서로 눌러야만 검색이 되었었는데 이젠 Enter쳐도 검색뜹니다

**수정사항 2. 초기화기능**
검색 후 초기화면으로 돌아가기 불가능
-> 헤더의 로고를 누르면 초기 화면이 뜹니다

**수정사항 3. 검색 후 제목**
검색 후 '요일 순 웹툰'이라는 제목이 유지되었었는데 '검색결과'가 뜨도록 변경함

-------------------------------

**문제 1. 썸네일 안뜸**
이미지 안뜨는 문제들이 있었는데 
`thumbnail": "https://kr-a.kakaopagecdn.com/P/C/1024/c1/2x/8092b6e6-38fa-46ec-9aec-8160a66714e5.png,https://kr-a.kakaopagecdn.com/P/C/1024/c2/2x/27c9511f-d3ea-427a-be42-364d218a8900.png,https://kr-a.kakaopagecdn.com/P/C/1024/bg/2x/39b615e2-db57-4f20-ab7a-32df9df49dd8.jpg`
이런 식으로 콤마(,)기준으로 여러개의 이미지 파일들이 있어서 불가능했었습니다. 
`thumbnail: item.thumbnail ? item.thumbnail.split(",")[0] : "",`
이렇게 해결함 별건 아니긴 하다만 적어봤습니다.

**문제 2. 검색결과일치**
검색어 입력 -> 검색 결과가 모두 일치한 문제
: 백엔드 쪽 재배포 후 해결
